### PR TITLE
ci: Trigger action on push

### DIFF
--- a/.github/workflows/05-train.yml
+++ b/.github/workflows/05-train.yml
@@ -1,6 +1,6 @@
-name: Manually trigger an Azure Machine Learning job
+name: Train model
 
-on: [ pull_request ]
+on: [ push ]
 
 jobs:
   train-model:

--- a/.github/workflows/05-train.yml
+++ b/.github/workflows/05-train.yml
@@ -1,6 +1,9 @@
 name: Train model
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   train-model:


### PR DESCRIPTION
Trigger the model training on `push` instead of `pull_request`